### PR TITLE
flo: Fix the typo in setup-makefiles-sh

### DIFF
--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -4,7 +4,7 @@ VENDOR=asus
 DEVICE=flo
 OUTDIR=vendor/$VENDOR/$DEVICE
 MAKEFILE=../../../$OUTDIR/$DEVICE-vendor-blobs.mk
-YEAR=`date +"%Y"
+YEAR=`date +"%Y"`
 
 (cat << EOF) > $MAKEFILE
 # Copyright (C) $YEAR The CyanogenMod Project


### PR DESCRIPTION
Add the mssing "`"

Signed-off-by: Yong Li sdliyong@gmail.com
